### PR TITLE
VPCネットワークモジュールを追加し、Cloud RunサービスのVPCコネクタを更新

### DIFF
--- a/.github/workflows/terraform-modules-test.yml
+++ b/.github/workflows/terraform-modules-test.yml
@@ -1,0 +1,22 @@
+name: "Terraform Modules Test"
+
+on:
+  push:
+    paths:
+      - "infra/modules/**"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        module: [network, cloud_run]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+      - name: Test ${{ matrix.module }}
+        working-directory: infra/modules/${{ matrix.module }}
+        run: |
+          terraform init -backend=false
+          terraform test

--- a/README.md
+++ b/README.md
@@ -125,10 +125,10 @@ cp .env.example .env
 make setup-snowflake
 
 # Airflow & データパイプライン起動
-docker-compose up -d
+docker compose up -d
 
 # パイプラインを手動トリガー（初回データロード）
-docker-compose exec airflow airflow dags trigger dex_liquidity_raw
+docker compose exec airflow airflow dags trigger dex_liquidity_raw
 ```
 
 4. dbt による変換
@@ -143,13 +143,13 @@ dbt build
 - 初回／週次再学習
 
 ```bash
-docker-compose exec airflow airflow dags trigger retrain_iforest
+docker compose exec airflow airflow dags trigger retrain_iforest
 ```
 
 - 毎時推論
 
 ```bash
-docker-compose exec airflow airflow dags trigger predict_pool_iforest
+docker compose exec airflow airflow dags trigger predict_pool_iforest
 ```
 
 6. API サーバー起動

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -1,7 +1,6 @@
 TF_DIR := $(CURDIR)
 
-# 引数が無ければ dev
-WORKSPACE ?= dev
+WORKSPACE ?= dev   # 引数が無ければ dev
 AUTOAPPROVE  ?=    # CI で -auto-approve を渡す用
 INIT_FLAGS ?=      # 例: "-upgrade -reconfigure"
 
@@ -12,12 +11,25 @@ select-workspace:
 	    && terraform workspace select $(WORKSPACE) \
 	    || terraform workspace new $(WORKSPACE))
 
-## 一般コマンド
+## ---------- モジュール単体テスト ----------
+.PHONY: test-modules
+test-modules: ## infra/modules/* の test.sh をすべて実行
+	for dir in infra/modules/*; do \
+	  if [ -x $$dir/test.sh ]; then \
+	    echo "▶ Testing $$dir"; \
+	    (cd $$dir && ./test.sh); \
+	  fi \
+	done
+
+## ---------- 一般コマンド ----------
 init:  ## terraform init $(INIT_FLAGS)
 	cd $(TF_DIR) && terraform init $(INIT_FLAGS)
 
-plan: select-workspace
+plan: select-workspace ## terraform plan
 	cd $(TF_DIR) && terraform plan
+
+validate: select-workspace ## terraform validate
+	cd $(TF_DIR) && terraform validate
 
 apply: guard-prod select-workspace ## terraform apply $(AUTOAPPROVE)
 	cd $(TF_DIR) && terraform apply $(AUTOAPPROVE)

--- a/infra/modules/network/.terraform.lock.hcl
+++ b/infra/modules/network/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = "~> 5.45"
+  hashes = [
+    "h1:iy2Q9VcnMu4z/bH3v/NmI/nEpgYY7bXgJmT/hVTAUS4=",
+    "zh:0d09c8f20b556305192cdbe0efa6d333ceebba963a8ba91f9f1714b5a20c4b7a",
+    "zh:117143fc91be407874568df416b938a6896f94cb873f26bba279cedab646a804",
+    "zh:16ccf77d18dd2c5ef9c0625f9cf546ebdf3213c0a452f432204c69feed55081e",
+    "zh:3e555cf22a570a4bd247964671f421ed7517970cd9765ceb46f335edc2c6f392",
+    "zh:688bd5b05a75124da7ae6e885b2b92bd29f4261808b2b78bd5f51f525c1052ca",
+    "zh:6db3ef37a05010d82900bfffb3261c59a0c247e0692049cb3eb8c2ef16c9d7bf",
+    "zh:70316fde75f6a15d72749f66d994ccbdde5f5ed4311b6d06b99850f698c9bbf9",
+    "zh:84b8e583771a4f2bd514e519d98ed7fd28dce5efe0634e973170e1cfb5556fb4",
+    "zh:9d4b8ef0a9b6677935c604d94495042e68ff5489932cfd1ec41052e094a279d3",
+    "zh:a2089dd9bd825c107b148dd12d6b286f71aa37dfd4ca9c35157f2dcba7bc19d8",
+    "zh:f03d795c0fd9721e59839255ee7ba7414173017dc530b4ce566daf3802a0d6dd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "5.45.2"
+  constraints = "~> 5.45"
+  hashes = [
+    "h1:ME/cVZGNln4h166gyo9r7CuunzZ3FEqlIaNyQ0e9yjE=",
+    "zh:16b77bac5d1555b7f066ba8014f4fc8a6d0de64e252a1988d3fbb400984a4b19",
+    "zh:1b13f515c4809343840aed8265915cc4191f138bdab5a8c5e1f542fdfc69989f",
+    "zh:1dcce4309aeab7c88fd36aea664d57e620d8a413b967ce513a5a866e8de901f2",
+    "zh:24db65d7929f2a731e9cac1750c569cb4528b312ef182a5e2e8c0cf008d8a71b",
+    "zh:28c0b9e68d97570f03b2c4770607701580055bcba50069efd145954aa13b23e4",
+    "zh:3a898a1ad1569f6486a2bc20014087284c8cab919bc8f155833de5128ccd12eb",
+    "zh:4eed99cfb9daada70f813f2cedcf490d3097de1ccb9b391fc451ecc46509c067",
+    "zh:888c4cb1f13b23674ba1091835dd3f1bff5d8e7729ef302183d8d01233819e54",
+    "zh:8baae3b949f6e9505425f5fa4785de786e9cedc4c3f3ad906d8ed560bd2e39c6",
+    "zh:cf2c8928b764592fa2cd14a9f109d01cd0a92049a4fca9d0a74cf2fe588364e2",
+    "zh:edff09394f5bd0b278a4adc800a31b7f150249a1ea92ca273ccf4acd25be3f63",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infra/modules/network/main.tf
+++ b/infra/modules/network/main.tf
@@ -1,0 +1,41 @@
+# 1) VPC ネットワーク作成
+resource "google_compute_network" "vpc" {
+  project                 = var.project_id
+  name                    = var.network_name
+  auto_create_subnetworks = false
+  routing_mode            = "REGIONAL"
+}
+
+# 2) プライマリリージョンサブネット追加
+resource "google_compute_subnetwork" "private" {
+  project                  = var.project_id
+  name                     = "${var.network_name}-subnet"
+  ip_cidr_range            = cidrsubnet(var.ip_cidr_range, 4, 0) # /24 範囲を分割
+  region                   = var.region
+  network                  = google_compute_network.vpc.id
+  private_ip_google_access = true # Secret Manager など Private Google APIs に到達するため設定
+}
+
+# 3) Serverless VPC Access Connector
+resource "google_vpc_access_connector" "connector" {
+  project       = var.project_id
+  name          = var.vpc_connector_name
+  region        = var.region
+  network       = google_compute_network.vpc.name
+  ip_cidr_range = var.connector_ip_cidr_range
+}
+
+# 4) インターネットへのアウトバウンドを許可
+resource "google_compute_firewall" "allow_egress_internet" {
+  name    = "${var.network_name}-egress"
+  project = var.project_id
+  network = google_compute_network.vpc.name
+
+  direction = "EGRESS"
+  allow {
+    protocol = "all"
+    ports    = ["0-65535"]
+  }
+  destination_ranges = ["0.0.0.0/0"]
+  priority           = 65534
+}

--- a/infra/modules/network/outputs.tf
+++ b/infra/modules/network/outputs.tf
@@ -1,0 +1,9 @@
+output "network_self_link" {
+  description = "作成した VPC ネットワークの self_link"
+  value       = google_compute_network.vpc.self_link
+}
+
+output "connector_id" {
+  description = "Serverless VPC Access Connector の ID"
+  value       = google_vpc_access_connector.connector.id
+}

--- a/infra/modules/network/terraform.tf
+++ b/infra/modules/network/terraform.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.45"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 5.45"
+    }
+  }
+}

--- a/infra/modules/network/test.sh
+++ b/infra/modules/network/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+terraform init -backend=false
+terraform test

--- a/infra/modules/network/test/network_basic.tftest.hcl
+++ b/infra/modules/network/test/network_basic.tftest.hcl
@@ -1,3 +1,4 @@
+# テスト用変数の定義
 variables {
   project_id              = "dummy-project"
   region                  = "asia-northeast1"
@@ -5,6 +6,7 @@ variables {
   connector_ip_cidr_range = "10.8.0.0/28"
 }
 
+# モジュールのパスを指定して plan 実行
 run "plan_network_module" {
   command = plan
 
@@ -12,6 +14,7 @@ run "plan_network_module" {
     source = "../"
   }
 
+  # 出力値チェック: connector_id が空ではない
   assert {
     condition     = length(run.plan_network_module.outputs.connector_id) > 0
     error_message = "connector_id 出力が空です"

--- a/infra/modules/network/test/network_basic.tftest.hcl
+++ b/infra/modules/network/test/network_basic.tftest.hcl
@@ -1,0 +1,19 @@
+variables {
+  project_id              = "dummy-project"
+  region                  = "asia-northeast1"
+  subnet_ip_cidr_range    = "10.9.0.0/24"
+  connector_ip_cidr_range = "10.8.0.0/28"
+}
+
+run "plan_network_module" {
+  command = plan
+
+  module {
+    source = "../"
+  }
+
+  assert {
+    condition     = length(run.plan_network_module.outputs.connector_id) > 0
+    error_message = "connector_id 出力が空です"
+  }
+}

--- a/infra/modules/network/variables.tf
+++ b/infra/modules/network/variables.tf
@@ -1,0 +1,39 @@
+variable "project_id" {
+  description = "GCP プロジェクト ID"
+  type        = string
+}
+
+variable "region" {
+  description = "デプロイ先リージョン"
+  type        = string
+}
+
+variable "network_name" {
+  description = "作成する VPC ネットワークの名前"
+  type        = string
+  default     = "dex-network"
+}
+
+variable "vpc_connector_name" {
+  description = "Serverless VPC Access Connector の名前"
+  type        = string
+  default     = "serverless-conn"
+}
+
+variable "ip_cidr_range" {
+  description = "VPC Access Connector に割り当てる IP CIDR 範囲"
+  type        = string
+  default     = "10.8.0.0/28"
+}
+
+variable "subnet_ip_cidr_range" {
+  description = "サブネットに割り当てる /24 などの CIDR"
+  type        = string
+  default     = "10.9.0.0/24"
+}
+
+variable "connector_ip_cidr_range" {
+  description = "Serverless VPC Access Connector 用 /28 CIDR"
+  type        = string
+  default     = "10.8.0.0/28"
+}


### PR DESCRIPTION
- VPCネットワークを作成するTerraformモジュールを追加
- VPCアクセスコネクタの設定をモジュール化
- Makefileにモジュール単体テストのターゲットを追加
- READMEを更新し、Terraform構成とワークスペース運用について記載
- GitHub ActionsにTerraformモジュールのテストワークフローを追加