### PR TITLE
CI/CDのエラー対応・Terraform ワークフローの整理

### DIFF
--- a/.github/workflows/cloudbuild-trigger.yml
+++ b/.github/workflows/cloudbuild-trigger.yml
@@ -1,4 +1,4 @@
-name: CI/CD via Cloud Build
+name: Cloud Build CI/CD
 
 on:
   push:

--- a/.github/workflows/terraform-apply-dev.yml
+++ b/.github/workflows/terraform-apply-dev.yml
@@ -1,0 +1,34 @@
+# dev への自動デプロイ用
+name: "Terraform Apply (dev)"
+
+on:
+  push:
+    branches: [dev]
+    paths: ["infra/**"]
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: terraform-dev-apply
+      cancel-in-progress: false # デプロイ中はキャンセルしない
+    steps:
+      # 1) リポジトリのチェックアウト
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # 2) Terraform をセットアップ
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.11.4
+
+      # 3) Terraform の初期化
+      - name: Initialize Terraform
+        run: terraform -chdir=infra init
+
+      # 4) Terraform の適用
+      - name: Apply Terraform
+        run: terraform -chdir=infra apply \
+          -input=false -auto-approve \
+          -lock-timeout=300s

--- a/.github/workflows/terraform-apply-prod.yml
+++ b/.github/workflows/terraform-apply-prod.yml
@@ -1,0 +1,31 @@
+# prod への手動デプロイ用
+name: "Terraform Apply (prod)"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    environment: production
+    concurrency:
+      group: terraform-prod-apply
+      cancel-in-progress: false # デプロイ中はキャンセルしない
+    steps:
+      # 1) リポジトリのチェックアウト
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # 2) Terraform をセットアップ
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+
+      # 3) Terraform の初期化
+      - name: Initialize Terraform
+        run: terraform -chdir=infra init
+
+      # 4) Terraform の適用
+      - name: Apply Terraform
+        run: terraform -chdir=infra apply \
+          -input=false -auto-approve \
+          -lock-timeout=300s

--- a/.github/workflows/terraform-modules-test.yml
+++ b/.github/workflows/terraform-modules-test.yml
@@ -2,19 +2,24 @@ name: "Terraform Modules Test"
 
 on:
   push:
-    paths:
-      - "infra/modules/**"
+    branches: [dev, main]
+    paths: ["infra/modules/**"]
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        module: [network, cloud_run]
+        module: [network]
     steps:
+      # 1) リポジトリのチェックアウト
       - uses: actions/checkout@v4
+
+      # 2) Terraform をセットアップ
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
+
+      # 3) モジュールのテスト
       - name: Test ${{ matrix.module }}
         working-directory: infra/modules/${{ matrix.module }}
         run: |

--- a/.github/workflows/terraform-plan-dev.yml
+++ b/.github/workflows/terraform-plan-dev.yml
@@ -1,0 +1,53 @@
+# dev へのプラン実行用
+name: "Terraform Plan (dev)"
+
+on:
+  pull_request:
+    paths: ["infra/**"]
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    env:
+      TF_WORKSPACE: dev
+    concurrency:
+      group: terraform-dev-plan # 同時実行防止
+      cancel-in-progress: true # 古いプランのみキャンセル
+    steps:
+      # 1) リポジトリのチェックアウト
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # 2) Terraform をセットアップ
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.11.4
+
+      # 3) Terraform の初期化
+      - name: Initialize Terraform
+        run: terraform -chdir=infra init
+
+      # 4) Terraform の検証
+      - name: Validate Terraform
+        run: terraform -chdir=infra validate
+
+      # 5) Terraform のフォーマットチェック
+      - name: Format Check
+        run: terraform -chdir=infra fmt -check
+
+      # 6) TFLint & TFsec の実行
+      - name: TFLint & TFsec
+        run: |
+          curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+          tflint --chdir infra
+          tfsec infra
+
+      # 7) Terraform Plan の実行
+      - name: Terraform Plan
+        id: plan
+        run: |
+          terraform -chdir=infra plan \
+            -lock-timeout=300s -no-color -detailed-exitcode \
+            -out=tfplan || \
+            [ $? -eq 2 ] || exit 1

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,14 +1,10 @@
-# -------- 置換変数 --------
+# 置換変数
 substitutions:
-  _TF_WORKSPACE: "dev" # dev / prod
   _PROJECT_ID: "portfolio-dex-dev"
   _REPO: "portfolio-docker-dev" # _PROJECT_ID に依存しない文字列
-  _ARTIFACTS_BUCKET: "portfolio-dex-mlflow-artifacts"
   _IMAGE_TAG: "local" # Pull Request ビルドなど
-  _APPLY_PROD: "no" # 手動で yes に切り替える
 
 steps:
-  # -------- Docker build --------
   # Bento
   - id: "Build & Push Bento"
     name: "gcr.io/cloud-builders/docker"
@@ -57,26 +53,7 @@ steps:
         ".",
       ]
 
-  # -------- Terraform (Makefile ラッパ) --------
-  - id: "Terraform"
-    name: "hashicorp/terraform:1.11.4"
-    entrypoint: sh
-    env:
-      - "PROJECT_ID=${_PROJECT_ID}"
-      - "ARTIFACTS_BUCKET=${_ARTIFACTS_BUCKET}"
-    args:
-      - -c
-      - |
-        apk add --no-cache make
-        cd infra
-        make init
-        make plan WORKSPACE=${_TF_WORKSPACE}
-        # dev は常に apply / prod は _APPLY_PROD=yes のときだけ
-        if [ "${_TF_WORKSPACE}" = "dev" ] || [ "${_APPLY_PROD}" = "yes" ]; then
-          make apply WORKSPACE=${_TF_WORKSPACE} AUTOAPPROVE=-auto-approve
-        fi
-
-# -------- 成果物 URI --------
+# 成果物 URI
 images:
   - "asia-northeast1-docker.pkg.dev/${_PROJECT_ID}/${_REPO}/bento:${_IMAGE_TAG}"
   - "asia-northeast1-docker.pkg.dev/${_PROJECT_ID}/${_REPO}/streamlit:${_IMAGE_TAG}"

--- a/infra/modules/network/main.tf
+++ b/infra/modules/network/main.tf
@@ -10,7 +10,7 @@ resource "google_compute_network" "vpc" {
 resource "google_compute_subnetwork" "private" {
   project                  = var.project_id
   name                     = "${var.network_name}-subnet"
-  ip_cidr_range            = cidrsubnet(var.ip_cidr_range, 4, 0) # /24 範囲を分割
+  ip_cidr_range            = var.subnet_ip_cidr_range
   region                   = var.region
   network                  = google_compute_network.vpc.id
   private_ip_google_access = true # Secret Manager など Private Google APIs に到達するため設定
@@ -34,7 +34,6 @@ resource "google_compute_firewall" "allow_egress_internet" {
   direction = "EGRESS"
   allow {
     protocol = "all"
-    ports    = ["0-65535"]
   }
   destination_ranges = ["0.0.0.0/0"]
   priority           = 65534


### PR DESCRIPTION
- Subnetworkが /32 になってしまう問題への対応
- Terraformの自動デプロイと手動デプロイ用のGitHub Actionsワークフローを追加
- Cloud Build構成を整理
- Terraformモジュールのplan, apply用のワークフローを作成
- Cloud Build ワークフローから Terraform ステップを削除