### PR TITLE
GCP OIDC 認証のため id-token 権限を付与

### DIFF
--- a/.github/workflows/terraform-apply-dev.yml
+++ b/.github/workflows/terraform-apply-dev.yml
@@ -1,6 +1,11 @@
 # dev への自動デプロイ用
 name: "Terraform Apply (dev)"
 
+# パーミッション設定
+permissions:
+  contents: read
+  id-token: write
+
 on:
   push:
     branches: [dev]

--- a/.github/workflows/terraform-apply-prod.yml
+++ b/.github/workflows/terraform-apply-prod.yml
@@ -1,6 +1,11 @@
 # prod への手動デプロイ用
 name: "Terraform Apply (prod)"
 
+# パーミッション設定
+permissions:
+  contents: read
+  id-token: write
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
- terraform-apply-{dev|prod}.yml のワークフローにpermissions設定を追加