### PR TITLE
secretsモジュールのIAMバインディングfor_eachキーをインデックス化して静的に設定

### DIFF
--- a/infra/modules/secrets/main.tf
+++ b/infra/modules/secrets/main.tf
@@ -14,8 +14,8 @@ locals {
 # Secret に対して accessor 権限を付与
 resource "google_secret_manager_secret_iam_member" "accessor" {
   for_each = {
-    for b in local.bindings :
-    "${b.secret_id}-${b.email}" => b
+    for idx, b in local.bindings :
+    "${b.secret_id}-${idx}" => b
   }
 
   project   = var.project_id


### PR DESCRIPTION
- for_eachのキーにサービスアカウントメールアドレスを含めていたことから、plan 時点で unknown となりエラーが発生するため修正
- インデックス(idx)をキーに含めることで、静的な for_each マップに