### PR TITLE
Dev Container CI ワークフローにキャッシュ対応を追加 (#27)

### DIFF
--- a/.github/workflows/devcontainer-ci.yml
+++ b/.github/workflows/devcontainer-ci.yml
@@ -16,20 +16,23 @@ jobs:
       packages: write
 
     steps:
-      # ソースをチェックアウト
-      - uses: actions/checkout@v4
+      # 1) リポジトリのチェックアウト
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      # テスト用の profiles.yml を作成
+      # 2) テスト用の profiles.yml を作成
       - name: Prepare ci_profiles
         run: |
           mkdir -p ci_profiles
           cp profiles/profiles.yml ci_profiles/
 
-      # Dev Container をビルド & 起動
-      - name: Run tasks in Dev Container
+      # 3) Dev Container をビルド & 起動
+      - name: Build & test in Dev Container
         uses: devcontainers/ci@v0.3
         with:
-          push: never
+          imageName: ghcr.io/${{ github.repository }}-devcontainer
+          cacheFrom: ghcr.io/${{ github.repository }}-devcontainer
+          push: ${{ github.event_name == 'push' && github.ref_name == 'main' && 'always' || 'never' }}
           env: ".devcontainer/devcontainer.env"
           runCmd: |
             echo "🧹 Ruff lint"


### PR DESCRIPTION
* Dev Container CI ワークフローにキャッシュ対応を追加

- imageName/cacheFrom: ghcr.io/${{ github.repository }}-devcontainer をレイヤキャッシュとして利用