### PR TITLE
BentoMLコンテナにMLflow本番連携を追加 

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -8,7 +8,7 @@ substitutions:
 # Secret Manager から取り出すシークレット定義
 availableSecrets:
   secretManager:
-    - versionName: "projects/${PROJECT_NUMBER}/secrets/mlflow-token/versions/latest"
+    - versionName: "projects/${PROJECT_ID}/secrets/mlflow-token/versions/latest"
       env: MLFLOW_TOKEN
 
 steps:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,6 +3,7 @@ substitutions:
   _PROJECT_ID: "portfolio-dex-dev"
   _REPO: "portfolio-docker-dev" # _PROJECT_ID に依存しない文字列
   _IMAGE_TAG: "local" # Pull Request ビルドなど
+  _MLFLOW_TRACKING_URI: "https://mlflow-dev-asia-northeast1.run.app"
 
 # Secret Manager から取り出すシークレット定義
 availableSecrets:
@@ -15,7 +16,7 @@ steps:
   - id: "Build & Push Bento"
     name: "gcr.io/cloud-builders/docker"
     env:
-      - "MLFLOW_TRACKING_URI=https://mlflow-dev-asia-northeast1.run.app"
+      - "MLFLOW_TRACKING_URI=${_MLFLOW_TRACKING_URI}"
     args:
       [
         "buildx",
@@ -25,7 +26,7 @@ steps:
         "asia-northeast1-docker.pkg.dev/${_PROJECT_ID}/${_REPO}/bento:${_IMAGE_TAG}",
         "--push",
         "--build-arg",
-        "MLFLOW_TRACKING_URI=${MLFLOW_TRACKING_URI}",
+        "MLFLOW_TRACKING_URI=${_MLFLOW_TRACKING_URI}",
         "--build-arg",
         "MLFLOW_TOKEN=${MLFLOW_TOKEN}",
         "-f",

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,10 +4,18 @@ substitutions:
   _REPO: "portfolio-docker-dev" # _PROJECT_ID に依存しない文字列
   _IMAGE_TAG: "local" # Pull Request ビルドなど
 
+# Secret Manager から取り出すシークレット定義
+availableSecrets:
+  secretManager:
+    - versionName: "projects/${PROJECT_NUMBER}/secrets/mlflow-token/versions/latest"
+      env: MLFLOW_TOKEN
+
 steps:
   # Bento
   - id: "Build & Push Bento"
     name: "gcr.io/cloud-builders/docker"
+    env:
+      - "MLFLOW_TRACKING_URI=https://mlflow-dev-asia-northeast1.run.app"
     args:
       [
         "buildx",
@@ -16,6 +24,10 @@ steps:
         "-t",
         "asia-northeast1-docker.pkg.dev/${_PROJECT_ID}/${_REPO}/bento:${_IMAGE_TAG}",
         "--push",
+        "--build-arg",
+        "MLFLOW_TRACKING_URI=${MLFLOW_TRACKING_URI}",
+        "--build-arg",
+        "MLFLOW_TOKEN=${MLFLOW_TOKEN}",
         "-f",
         "docker/bento/Dockerfile",
         ".",

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,8 +18,7 @@ steps:
     secretEnv: ["MLFLOW_TOKEN"]
     env:
       - "MLFLOW_TRACKING_URI=${_MLFLOW_TRACKING_URI}"
-    args:
-      [
+    args: [
         "buildx",
         "build",
         "--platform=linux/amd64",
@@ -29,7 +28,7 @@ steps:
         "--build-arg",
         "MLFLOW_TRACKING_URI=${_MLFLOW_TRACKING_URI}",
         "--build-arg",
-        "MLFLOW_TOKEN=${MLFLOW_TOKEN}",
+        "MLFLOW_TOKEN=$$MLFLOW_TOKEN", # シークレットから取得
         "-f",
         "docker/bento/Dockerfile",
         ".",

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -8,7 +8,7 @@ substitutions:
 # Secret Manager から取り出すシークレット定義
 availableSecrets:
   secretManager:
-    - versionName: "projects/${PROJECT_ID}/secrets/mlflow-token/versions/latest"
+    - versionName: "projects/${_PROJECT_ID}/secrets/mlflow-token/versions/latest"
       env: MLFLOW_TOKEN
 
 steps:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -15,6 +15,7 @@ steps:
   # Bento
   - id: "Build & Push Bento"
     name: "gcr.io/cloud-builders/docker"
+    secretEnv: ["MLFLOW_TOKEN"]
     env:
       - "MLFLOW_TRACKING_URI=${_MLFLOW_TRACKING_URI}"
     args:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,6 +12,24 @@ availableSecrets:
       env: MLFLOW_TOKEN
 
 steps:
+  - id: "Debug Env"
+    name: "gcr.io/cloud-builders/gcloud"
+    entrypoint: "bash"
+    args:
+      - "-c"
+      - |
+        echo "=== Substitutions ==="
+        echo "_PROJECT_ID=${_PROJECT_ID}"
+        echo "_REPO=${_REPO}"
+        echo "_IMAGE_TAG=${_IMAGE_TAG}"
+        echo "=== Env Vars ==="
+        env
+        echo "=== Secret Access Test ==="
+
+        gcloud secrets versions access latest \
+          --secret=mlflow-token \
+          --project=${_PROJECT_ID}
+
   # Bento
   - id: "Build & Push Bento"
     name: "gcr.io/cloud-builders/docker"

--- a/docker/bento/Dockerfile
+++ b/docker/bento/Dockerfile
@@ -19,6 +19,15 @@ RUN pip install --no-cache-dir \
   graphviz==0.20.3 \
   pyarrow==16.1.0
 
+# MLflow からモデルをインポート
+ARG MLFLOW_TRACKING_URI
+ARG MLFLOW_TOKEN
+ENV MLFLOW_TRACKING_URI=${MLFLOW_TRACKING_URI}
+ENV MLFLOW_TOKEN=${MLFLOW_TOKEN}
+
+# idempotent にインポート（存在すればスキップ）
+RUN python scripts/import_volume_spike_model.py || true
+
 # ---------- 2. runtime stage ----------
 FROM --platform=linux/amd64 python:3.11-slim
 RUN apt-get update && \

--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -1,6 +1,6 @@
 locals {
   # GCP プロジェクト ID
-  project_id = terraform.workspace == "prod" ? "portfolio-dex-prod" : "portfolio-dex-dev"
+  project_id = terraform.workspace == "prod" ? "portfolio-dex-prod-460122" : "portfolio-dex-dev"
 
   # デプロイ先リージョン
   region = "asia-northeast1"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -46,6 +46,9 @@ module "secrets" {
     # Streamlit SA へ snowflake-pass / snowflake-user の accessor を付与
     "snowflake-pass" = [module.service_accounts.emails["streamlit"]]
     "snowflake-user" = [module.service_accounts.emails["streamlit"]]
+
+    # Bento SA へ mlflow-token の accessor を付与
+    "mlflow-token" = [module.service_accounts.emails["bento"]]
   }
 }
 
@@ -76,7 +79,14 @@ module "cloud_run_bento" {
   ]
 
   env_vars = {
-    MLFLOW_TRACKING_URI = "http://mlflow:5000"
+    MLFLOW_TRACKING_URI = "https://mlflow-${local.env}-${local.region}.run.app"
+  }
+
+  secret_env_vars = {
+    MLFLOW_TOKEN = {
+      secret  = "mlflow-token"
+      version = "latest"
+    }
   }
 }
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -65,13 +65,15 @@ module "artifact_registry" {
 
 # BentoML API
 module "cloud_run_bento" {
-  source         = "./modules/cloud_run"
-  project_id     = local.project_id
-  name           = "bento-api-${local.env}"
-  location       = local.region
-  image          = "asia-northeast1-docker.pkg.dev/${local.project_id}/portfolio-docker-${local.env}/bento:latest"
-  vpc_connector  = module.network.connector_id
-  container_port = 3000
+  source                = "./modules/cloud_run"
+  project_id            = local.project_id
+  name                  = "bento-api-${local.env}"
+  location              = local.region
+  image                 = "asia-northeast1-docker.pkg.dev/${local.project_id}/portfolio-docker-${local.env}/bento:latest"
+  vpc_connector         = module.network.connector_id
+  container_port        = 3000
+  service_account_email = module.service_accounts.emails["bento"]
+
 
   depends_on = [
     module.artifact_registry,

--- a/scripts/start_bento.sh
+++ b/scripts/start_bento.sh
@@ -1,16 +1,11 @@
 #!/usr/bin/env sh
 set -eu
 
-# モデルインポートをスキップ
-echo "Starting BentoML service in simple mode..."
-
-# # モデル検証
-# python -u scripts/import_volume_spike_model.py
+# モデル検証
+python -u scripts/import_volume_spike_model.py
 
 # BentoML サービスを起動
-# Cloud Run の環境変数 PORT を使って、0.0.0.0 にバインド
-# 一時的にMLFlowへの依存なしのサービスを起動
-exec bentoml serve services.simple_service:SimpleService \
+exec bentoml serve services.volume_spike_service:PoolIForestService \
   --reload \
   --host 0.0.0.0 \
   --port "${PORT:-3000}"


### PR DESCRIPTION
- Cloud Build (cloudbuild.yaml) に Secret Manager から mlflow-token を取得する設定を追加
- BentoML 用 Dockerfile でビルド時に MLflow Registry からモデルを idempotent にインポートする処理を実装
- infra/main.tf で Bento のサービスアカウントに mlflow-token の accessor 権限を付与し、Cloud Run Bento モジュールに MLFLOW_TOKEN シークレットを設定
- scripts/start_bento.sh を本番サービス起動用に修正し、PoolIForestService を起動するよう変更