### PR TITLE
Cloud BuildにMLflow URI置換追加＆Cloud Run Bento用SA指定を追加

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,6 +3,7 @@ substitutions:
   _PROJECT_ID: "portfolio-dex-dev"
   _REPO: "portfolio-docker-dev" # _PROJECT_ID に依存しない文字列
   _IMAGE_TAG: "local" # Pull Request ビルドなど
+  _MLFLOW_TRACKING_URI: "https://mlflow-dev-asia-northeast1.run.app"
 
 # Secret Manager から取り出すシークレット定義
 availableSecrets:
@@ -15,7 +16,7 @@ steps:
   - id: "Build & Push Bento"
     name: "gcr.io/cloud-builders/docker"
     env:
-      - "MLFLOW_TRACKING_URI=https://mlflow-dev-asia-northeast1.run.app"
+      - "MLFLOW_TRACKING_URI=${_MLFLOW_TRACKING_URI}"
     args:
       [
         "buildx",
@@ -25,7 +26,7 @@ steps:
         "asia-northeast1-docker.pkg.dev/${_PROJECT_ID}/${_REPO}/bento:${_IMAGE_TAG}",
         "--push",
         "--build-arg",
-        "MLFLOW_TRACKING_URI=${MLFLOW_TRACKING_URI}",
+        "MLFLOW_TRACKING_URI=${_MLFLOW_TRACKING_URI}",
         "--build-arg",
         "MLFLOW_TOKEN=${MLFLOW_TOKEN}",
         "-f",

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -65,13 +65,15 @@ module "artifact_registry" {
 
 # BentoML API
 module "cloud_run_bento" {
-  source         = "./modules/cloud_run"
-  project_id     = local.project_id
-  name           = "bento-api-${local.env}"
-  location       = local.region
-  image          = "asia-northeast1-docker.pkg.dev/${local.project_id}/portfolio-docker-${local.env}/bento:latest"
-  vpc_connector  = module.network.connector_id
-  container_port = 3000
+  source                = "./modules/cloud_run"
+  project_id            = local.project_id
+  name                  = "bento-api-${local.env}"
+  location              = local.region
+  image                 = "asia-northeast1-docker.pkg.dev/${local.project_id}/portfolio-docker-${local.env}/bento:latest"
+  vpc_connector         = module.network.connector_id
+  container_port        = 3000
+  service_account_email = module.service_accounts.emails["bento"]
+
 
   depends_on = [
     module.artifact_registry,


### PR DESCRIPTION
- cloudbuild.yaml に `_MLFLOW_TRACKING_URI` を substitutions に追加
- infra/main.tf の `module "cloud_run_bento"` でBento 用サービスアカウントで Cloud Run を動作させるように