### PR TITLE
Cloud Buildシークレット参照先とTerraform localsのprodプロジェクトIDを修正

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -8,7 +8,7 @@ substitutions:
 # Secret Manager から取り出すシークレット定義
 availableSecrets:
   secretManager:
-    - versionName: "projects/${PROJECT_NUMBER}/secrets/mlflow-token/versions/latest"
+    - versionName: "projects/${PROJECT_ID}/secrets/mlflow-token/versions/latest"
       env: MLFLOW_TOKEN
 
 steps:

--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -1,6 +1,6 @@
 locals {
   # GCP プロジェクト ID
-  project_id = terraform.workspace == "prod" ? "portfolio-dex-prod" : "portfolio-dex-dev"
+  project_id = terraform.workspace == "prod" ? "portfolio-dex-prod-460122" : "portfolio-dex-dev"
 
   # デプロイ先リージョン
   region = "asia-northeast1"


### PR DESCRIPTION
- cloudbuild.yaml の availableSecrets.versionName を ${PROJECT_NUMBER} から ${PROJECT_ID} に変更
- infra/locals.tf の prod 環境用 project_id を portfolio-dex-prod → portfolio-dex-prod-460122 に更新