### PR TITLE
SushiSwap エンドポイントを Uniswap と同形式に統一

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,33 @@
 repos:
   - repo: https://github.com/kynan/nbstripout
-    rev: v0.5.0
+    rev: v0.8.1
     hooks:
       - id: nbstripout
+
+  # pre-commit公式
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-yaml
+      - id: check-json
+      - id: check-toml
+      - id: check-merge-conflict # マージコンフリクトマーカーのチェック
+      - id: end-of-file-fixer # ファイル末尾の空行を修正
+      - id: trailing-whitespace # 行末の不要な空白を削除
+
+  # Ruff (Python Linter & Formatter)
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.10
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix] # 自動修正し、修正があった場合はエラー終了 (再コミットを促す)
+      - id: ruff-format # Ruffのフォーマッター機能
+
+  # Terraform Hooks
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.90.0
+    hooks:
+      - id: terraform_fmt # Terraform フォーマット
+      - id: terraform_validate # Terraform バリデーション
+      - id: terraform_tflint # TFLint
+      - id: terraform_tfsec # TFSec

--- a/protocols.yml
+++ b/protocols.yml
@@ -7,5 +7,5 @@ uniswap:
 sushiswap:
   api_key: ${THE_GRAPH_API_KEY}
   subgraph_id: ${THE_GRAPH_SUSHISWAP_SUBGRAPH_ID}
-  endpoint_template: "https://gateway.thegraph.com/api/subgraphs/id/{subgraph_id}"
+  endpoint_template: "https://gateway.thegraph.com/api/{api_key}/subgraphs/id/{subgraph_id}"
   page_size: 1000

--- a/scripts/fetcher/sushiswap.py
+++ b/scripts/fetcher/sushiswap.py
@@ -17,5 +17,4 @@ def build_sushiswap_fetcher() -> BaseFetcher:
     endpoint: str = cfg["endpoint_template"].format(
         api_key=cfg["api_key"], subgraph_id=cfg["subgraph_id"]
     )
-    headers: Dict[str, str] = {"Authorization": f"Bearer {cfg['api_key']}"}
-    return BaseFetcher("sushiswap", endpoint, _SUSHI_QUERY, cfg["page_size"], headers)
+    return BaseFetcher("sushiswap", endpoint, _SUSHI_QUERY, cfg["page_size"])


### PR DESCRIPTION
- サブグラフのエンドポイントテンプレートを修正し、Sushiswapフェッチャーから不要なヘッダーを削除
- pre-commit設定を更新
