### PR TITLE
Refactor/ci cd

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN poetry config virtualenvs.create false \
 # ---------- SnowSQL インストール ----------
 RUN curl -O https://sfc-repo.snowflakecomputing.com/snowsql/bootstrap/1.2/linux_x86_64/snowsql-1.2.26-linux_x86_64.bash && \
   chmod 755 snowsql-1.2.26-linux_x86_64.bash && \
-  SNOWSQL_DEST=/usr/local/bin SNOWSQL_LOGIN_SHELL=/dev/null bash snowsql-1.2.26-linux_x86_64.bash -batch || true && \
+  SNOWSQL_DEST=/usr/local/bin SNOWSQL_LOGIN_SHELL=/dev/null bash snowsql-1.2.26-linux_x86_64.bash -batch || { cat snowsql*.log; exit 1; } && \
   rm snowsql-1.2.26-linux_x86_64.bash
 
 # ---------- vscode ユーザーに切り替え ----------

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,11 +8,14 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/node:1": { "version": "lts" },
-    "ghcr.io/eitsupi/devcontainer-features/duckdb-cli:1": {},
+    "ghcr.io/eitsupi/devcontainer-features/duckdb-cli:1": {
+      "VERSION": "1.2.2"
+    },
     "ghcr.io/devcontainers/features/terraform:1": {
       "tflint": "latest",
       "installTFsec": true
-    }
+    },
+    "ghcr.io/duduribeiro/devcontainer-features/tmux:1": {}
   },
   "forwardPorts": [
     8080, // Airflow Web UI

--- a/.github/workflows/_terraform-plan.yml
+++ b/.github/workflows/_terraform-plan.yml
@@ -63,15 +63,30 @@ jobs:
 
       # 10) Trivy IaC スキャン
       - name: Run Trivy IaC scanner
+        id: trivy
         uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: "config"
           scan-ref: "./infra"
           severity: "HIGH,CRITICAL"
           output: trivy-scan-result.txt
-          exit-code: "1"
+          exit-code: "0"
 
-      # 11) Terraform Plan の実行
+      # 11) PR へ Trivy スキャン結果コメント
+      - name: Comment Trivy scan result to PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('trivy-scan-result.txt', 'utf8');
+            github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+
+      # 12) Terraform Plan の実行
       - name: Terraform Plan
         id: plan
         run: |
@@ -80,7 +95,7 @@ jobs:
             -out=tfplan || \
             [ $? -eq 2 ] || exit 1
 
-      # 12) PR へ Plan コメント
+      # 13) PR へ Plan コメント
       - name: Comment plan to PR
         if: github.event_name == 'pull_request'
         uses: robburger/terraform-pr-commenter@v1

--- a/.github/workflows/cloudbuild-trigger.yml
+++ b/.github/workflows/cloudbuild-trigger.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      ENV: dev
+      ENV: ${{ github.event.inputs.workspace || 'dev' }}
       PROJECT_ID: ${{ secrets.PROJECT_ID }}
       TF_SA_EMAIL: ${{ secrets.TF_SA_EMAIL }}
       ARTIFACTS_BUCKET: ${{ secrets.ARTIFACTS_BUCKET }}

--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,8 @@ mlruns/
 .terraform/
 
 # Terraform State files
-terraform.tfstate
-terraform.tfstate.backup
+*.tfstate
+*.tfstate.*
 
 # Terraform override files
 override.tf


### PR DESCRIPTION
- dev containerにtmuxを追加  
  - dev containerでのduckdb-cliのバージョンを1.2.2に更新
  - .gitignoreのTerraform状態ファイルのパターンを一括指定に変更
- Cloud Build の workspace 変数統一
  - prod イメージに dev タグが付かないように
- DockerfileのSnowSQLインストール失敗時にログを表示
- GitHub ActionsのTerraform PlanワークフローでのTrivyスキャン結果をPRにコメントとして追加
  - Trivyのexit-codeを0に変更。