### PR TITLE
Cloud Run SA の IAM で権限を調整 (#83)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,11 @@
 - 毎時推論 DAG（`predict_pool_iforest`）
 - BentoML API & Streamlit ダッシュボード
 - CI/CD（GitHub Actions）ワークフロー
-- Terraform でのベースインフラ（Cloud Run / Secret Manager / VPC）
+- Terraform による Cloud Run・Secret Manager・VPC 基盤構築と IAM 権限制御の最適化
 
 **🚧 開発中**
 
 - Cloud Composer 3（dev 環境）への Airflow DAG デプロイ
-- 権限制御 (IAM 最小権限ポリシー) の細分化
 - EDA Notebook の整備＆リポジトリへの追加
 
 **⏳ 実装予定**

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -1,3 +1,35 @@
+# Cloud Run カスタム SA に付与するロール
+locals {
+  # Cloud Run に必須な role を付与
+  sa_roles = {
+    bento     = ["roles/logging.logWriter", "roles/monitoring.metricWriter"]
+    streamlit = ["roles/logging.logWriter", "roles/monitoring.metricWriter"]
+    airflow   = ["roles/logging.logWriter", "roles/monitoring.metricWriter"] # Airflow 用 Cloud Run がある場合
+  }
+
+  # flatten して for_each 可能な形に変換
+  iam_bindings = {
+    for item in flatten([
+      for sa_name, roles in local.sa_roles : [
+        for role in roles : {
+          key     = "${sa_name}-${role}"
+          sa_name = sa_name
+          role    = role
+        }
+      ]
+    ]) : item.key => item
+  }
+}
+
+# 動的に IAM を付与
+resource "google_project_iam_member" "sa_min_roles" {
+  for_each = local.iam_bindings
+
+  project = local.project_id
+  role    = each.value.role
+  member  = "serviceAccount:${module.service_accounts.emails[each.value.sa_name]}"
+}
+
 # Cloud Run の invoker ロールを付与
 resource "google_project_iam_member" "composer_run_invoker" {
   project = local.project_id


### PR DESCRIPTION
- bento / streamlit / airflow 各サービスアカウントに roles/logging.logWriter と roles/monitoring.metricWriter のみを付与
- Composer SA → Cloud Run Invoker 権限を iam_minimal.tf に移動
- README を更新