### PR TITLE
env_suffix 変数を追加し、 CI・Makefile・READMEを更新 (#87)

### DIFF
--- a/.github/workflows/_terraform-plan.yml
+++ b/.github/workflows/_terraform-plan.yml
@@ -40,6 +40,8 @@ jobs:
 
       # 5) Terraform の検証
       - name: Validate Terraform
+        env:
+          TF_VAR_env_suffix: ${{ inputs.workspace }}
         run: terraform -chdir=infra validate
 
       # 6) Terraform のフォーマットチェック
@@ -98,6 +100,7 @@ jobs:
         run: |
           terraform -chdir=infra plan \
             -lock-timeout=300s -no-color -detailed-exitcode \
+            -var "env_suffix=${{ inputs.workspace }}" \
             -out=tfplan || [ $? -eq 2 ] || exit 1
 
       # 13) PR へ Plan コメント

--- a/.github/workflows/terraform-apply-dev.yml
+++ b/.github/workflows/terraform-apply-dev.yml
@@ -44,4 +44,4 @@ jobs:
 
       # 5) Terraform の適用
       - name: Apply Terraform
-        run: terraform -chdir=infra apply -input=false -auto-approve -lock-timeout=300s
+        run: terraform -chdir=infra apply -input=false -auto-approve -lock-timeout=300s -var "env_suffix=dev"

--- a/.github/workflows/terraform-apply-prod.yml
+++ b/.github/workflows/terraform-apply-prod.yml
@@ -43,4 +43,4 @@ jobs:
 
       # 5) Terraform の適用
       - name: Apply Terraform
-        run: terraform -chdir=infra apply -input=false -auto-approve -lock-timeout=300s
+        run: terraform -chdir=infra apply -input=false -auto-approve -lock-timeout=300s -var "env_suffix=prod"

--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@
 - EDA: DuckDB
 - CI/CD: GitHub Actions
 
+### IaC
+
+- **Terraform** – Cloud Run / Secret Manager / VPC / IAM / Composer / GCS
+- 詳細手順・環境分岐については [`infra/README.md`](./infra/README.md) に記載
+
 ## 環境構築
 
 ### 利用サービス等

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -1,8 +1,11 @@
 TF_DIR := $(CURDIR)
 
-WORKSPACE ?= dev   # 引数が無ければ dev
-AUTOAPPROVE  ?=    # CI で -auto-approve を渡す用
-INIT_FLAGS ?=      # 例: "-upgrade -reconfigure"
+# 引数が無ければ dev
+WORKSPACE ?= dev
+# CI で -auto-approve を渡す用
+AUTOAPPROVE  ?=
+# 例: "-upgrade -reconfigure"
+INIT_FLAGS ?=
 
 ## 内部ヘルパー
 select-workspace:
@@ -26,16 +29,16 @@ init:  ## terraform init $(INIT_FLAGS)
 	cd $(TF_DIR) && terraform init $(INIT_FLAGS)
 
 plan: select-workspace ## terraform plan
-	cd $(TF_DIR) && terraform plan
+	cd $(TF_DIR) && terraform plan -var "env_suffix=$(WORKSPACE)"
 
 validate: select-workspace ## terraform validate
-	cd $(TF_DIR) && terraform validate
+	cd $(TF_DIR) && terraform validate -var "env_suffix=$(WORKSPACE)"
 
 apply: guard-prod select-workspace ## terraform apply $(AUTOAPPROVE)
-	cd $(TF_DIR) && terraform apply $(AUTOAPPROVE)
+	cd $(TF_DIR) && terraform apply $(AUTOAPPROVE) -var "env_suffix=$(WORKSPACE)"
 
 destroy: guard-prod select-workspace ## terraform destroy
-	cd $(TF_DIR) && terraform destroy
+	cd $(TF_DIR) && terraform destroy -var "env_suffix=$(WORKSPACE)"
 
 help:  ## ヘルプを表示
 	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \

--- a/infra/composer_sa.tf
+++ b/infra/composer_sa.tf
@@ -1,7 +1,7 @@
 # Composer 専用 SA を用意
 resource "google_service_account" "composer" {
-  account_id   = "composer-${terraform.workspace}"
-  display_name = "Composer SA (${terraform.workspace})"
+  account_id   = "composer-${local.env_suffix}"
+  display_name = "Composer SA (${local.env_suffix})"
 }
 
 # Composer Worker 権限を付与

--- a/infra/locals.tf
+++ b/infra/locals.tf
@@ -1,10 +1,13 @@
 locals {
+  # env_suffix が渡されていれば優先、無ければ workspace
+  env_suffix = var.env_suffix != "" ? var.env_suffix : terraform.workspace
+
   # GCP プロジェクト ID
-  project_id = terraform.workspace == "prod" ? "portfolio-dex-prod-460122" : "portfolio-dex-dev"
+  project_id = local.env_suffix == "prod" ? "portfolio-dex-prod-460122" : "portfolio-dex-dev"
 
   # デプロイ先リージョン
   region = "asia-northeast1"
 
   # MLflow のアーティファクトを置く GCS バケット名
-  artifacts_bucket = terraform.workspace == "prod" ? "portfolio-dex-mlflow-artifacts-prod" : "portfolio-dex-mlflow-artifacts"
+  artifacts_bucket = local.env_suffix == "prod" ? "portfolio-dex-mlflow-artifacts-prod" : "portfolio-dex-mlflow-artifacts"
 }

--- a/infra/modules/network/variables.tf
+++ b/infra/modules/network/variables.tf
@@ -8,6 +8,11 @@ variable "region" {
   type        = string
 }
 
+variable "env_suffix" {
+  description = "環境を区別するサフィックス (dev / prod)"
+  type        = string
+}
+
 variable "network_name" {
   description = "作成する VPC ネットワークの名前"
   type        = string

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -8,3 +8,10 @@ variable "composer_version" {
   description = "Composer のバージョン"
   default     = "composer-3-airflow-2.10.5-build.3"
 }
+
+# dev / prod を CLI から渡すために設定
+variable "env_suffix" {
+  description = "環境識別子 (dev / prod)。未指定なら terraform.workspace を使う"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
* env_suffix 変数を追加し、 CI・Makefile・READMEを更新

- GitHub ActionsのTerraform Plan、Applyステップに環境識別子（env_suffix）を追加
- locals.tfでenv_suffixを使用し、プロジェクトIDやバケット名を環境に応じて切り替え
- READMEに環境設定の説明を追加

* Terraformの検証ステップでenv変数を設定

- env_suffixを直接使用するように修正